### PR TITLE
Fixes issue with Match::byDate(2)

### DIFF
--- a/src/Rebing/Soccerama/Requests/Match.php
+++ b/src/Rebing/Soccerama/Requests/Match.php
@@ -15,11 +15,11 @@ class Match extends SocceramaClient {
     {
         if($fromDate instanceof Carbon)
         {
-            $fromDate->format('Y-m-d');
+            $fromDate = $fromDate->format('Y-m-d');
         }
         if($toDate instanceof Carbon)
         {
-            $toDate->format('Y-m-d');
+            $toDate = $toDate->format('Y-m-d');
         }
 
         return $this->callData('matches/' . $fromDate . '/' . $toDate);


### PR DESCRIPTION
Fixes issue where suppling a carbon instance to Match::byDate() would not correctly convert the $fromDate and $toDate variables to the format Y-m-d.