### PR TITLE
Adds some sort of error handling

### DIFF
--- a/src/Rebing/Soccerama/Exceptions/ApiRequestException.php
+++ b/src/Rebing/Soccerama/Exceptions/ApiRequestException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Rebing\Soccerama\Exceptions;
+
+use Exception;
+
+class ApiRequestException extends Exception 
+{}

--- a/src/Rebing/Soccerama/SocceramaClient.php
+++ b/src/Rebing/Soccerama/SocceramaClient.php
@@ -43,7 +43,7 @@ class SocceramaClient {
 
         $body = json_decode($response->getBody()->getContents());
 
-        if($body->error) 
+        if(property_exists($body, 'error')) 
         {
             if(is_object($body->error)) 
             {

--- a/src/Rebing/Soccerama/SocceramaClient.php
+++ b/src/Rebing/Soccerama/SocceramaClient.php
@@ -3,6 +3,7 @@
 namespace Rebing\Soccerama;
 
 use GuzzleHttp\Client;
+use Rebing\Soccerama\Exceptions\ApiRequestException;
 
 class SocceramaClient {
 
@@ -41,6 +42,20 @@ class SocceramaClient {
         $response = $this->client->get($url, ['query' => $query]);
 
         $body = json_decode($response->getBody()->getContents());
+
+        if($body->error) 
+        {
+            if(is_object($body->error)) 
+            {
+                throw new ApiRequestException($body->error->message, $body->error->code);
+            } 
+            else 
+            {
+                throw new ApiRequestException($body->error, 500);
+            }
+
+            return $response;
+        }
 
         if($hasData && $this->withoutData)
         {


### PR DESCRIPTION
At the moment there is zero error handling within the client. If a malformed request is sent or an error is spewed out by the API, the script will fail with a pretty useless undefined property error.

This adds at least a catchable error that can give more info on the error rather than having to add a die($response) into the code of the client itself.